### PR TITLE
Use #[non_exhaustive] on Error enum

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,7 @@ use std::io;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Error: {:?}", error)]
     Other { error: String },


### PR DESCRIPTION
Same as openrr/openrr#105

Note that this is a breaking change.