### PR TITLE
Rename use-assimp feature to assimp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ exclude = [".github/*", "img/*"]
 edition = "2018"
 
 [features]
-default = ["use-assimp"]
-use-assimp = ["assimp", "assimp-sys"]
+default = ["assimp"]
+assimp = ["assimp-crate", "assimp-sys"]
 
 # Note: k, kiss3d, nalgebra, serde, and urdf-rs are public dependencies.
 [dependencies]
@@ -29,5 +29,5 @@ serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3"
 thiserror = "1.0"
 urdf-rs = "0.6"
-assimp = { version = "0.3.1", optional = true }
+assimp-crate = { package = "assimp", version = "0.3.1", optional = true }
 assimp-sys = { version = "0.3.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ $ curl http://127.0.0.1:7777/get_robot_origin
 
 ## features
 
-default features is ["use-assimp"]. If you don't use mesh except for .obj files, you can skip install of assimp by disabling the feature like below.
+default features is ["assimp"]. If you don't use mesh except for .obj files, you can skip install of assimp by disabling the feature like below.
 
 ```bash
 cargo build --no-default-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@
 //!
 
 #[cfg(feature = "assimp")]
+extern crate assimp_crate as assimp;
+
+#[cfg(feature = "assimp")]
 mod assimp_utils;
 
 mod errors;


### PR DESCRIPTION
https://rust-lang.github.io/api-guidelines/naming.html#feature-names-are-free-of-placeholder-words-c-feature

> Do not include words in the name of a Cargo feature that convey zero meaning, as in `use-abc` or `with-abc`. Name the feature `abc` directly.

See also: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
