### PR TITLE
Release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags: [ "v[0-9]+.*" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'openrr'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies (linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install xorg-dev libglu1-mesa-dev
+
+      - run: cargo package
+
+      - uses: taiki-e/create-gh-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  upload-assets:
+    if: github.repository_owner == 'openrr'
+    needs: [ create-release ]
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies (linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install xorg-dev libglu1-mesa-dev
+        if: matrix.os == 'ubuntu-latest'
+
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: urdf-viz
+          archive: $bin-$tag-$target
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_PROFILE_RELEASE_LTO: true

--- a/README.md
+++ b/README.md
@@ -45,12 +45,11 @@ Install freetype by brew.
 brew install freetype
 ```
 
-<!-- TODO: re-add this
 ## Download binary
 
 If you don't want to install `rust` and `cargo`, you can find
-binary releases of `urdf-viz` for Ubuntu16.04/14.04 64bit, Windows, MacOS [here](https://github.com/OTL/urdf-viz/releases).
--->
+binary releases of `urdf-viz` for Linux, macOS [here](https://github.com/OTL/urdf-viz/releases).
+<!-- TODO: distribute binary for Windows -->
 
 ## How to use
 


### PR DESCRIPTION
This partially re-adds CI/CD for the release that was removed in #38.

The workflow added by this PR launches when the tag is pushed and does the following:

- Creates a GitHub release.
- Publishes the crate to crates.io.
- Uploads the binary to the GitHub release. (only Linux, macOS)

Except for publishing to crates.io, this PR has been tested in my fork repository: [result](https://github.com/taiki-e/urdf-viz/releases/tag/v0.23.1), [log](https://github.com/taiki-e/urdf-viz/actions/runs/536901803)

The following two actions are mainly used in this PR. These are the actions that were originally used for most of my rust projects and [have been moved to the current repository for use in projects other than `github.com/taiki-e`](https://github.com/taiki-e/github-actions#moved-actions).

- [create-gh-release-action](https://github.com/taiki-e/create-gh-release-action)
- [upload-rust-binary-action](https://github.com/taiki-e/upload-rust-binary-action)

