### PR TITLE
Remove tag name from release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: urdf-viz
-          archive: $bin-$tag-$target
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_PROFILE_RELEASE_LTO: true


### PR DESCRIPTION
See also https://github.com/rust-embedded/cross/issues/457

This changes release binary name from `$bin-$tag-$target` (e.g, `urdf-viz-v0.23.0-x86_64-unknown-linux-gnu`) to `$bin-$target` (e.g., `urdf-viz-x86_64-unknown-linux-gnu`).
This allows installing the latest urdf-viz with one command if you know the host os.
before(current):
```sh
tag_name=$(curl -LsSf https://api.github.com/repos/openrr/urdf-viz/releases/latest | jq -r '.tag_name')
curl -LsSf https://github.com/openrr/urdf-viz/releases/download/${tag_name}/urdf-viz-${tag_name}-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
```
after:
```sh
curl -LsSf https://github.com/openrr/urdf-viz/releases/latest/download/urdf-viz-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
```