### PR TITLE
Support exit by Ctrl-C

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ assimp = ["assimp-crate", "assimp-sys"]
 # Note: k, kiss3d, nalgebra, serde, and urdf-rs are public dependencies.
 [dependencies]
 actix-web = "3"
+ctrlc = { version = "3", features = ["termination"] }
 env_logger = "0.8"
 k = "0.23"
 kiss3d = "0.30"


### PR DESCRIPTION
Currently, urdf-viz cannot be exit by Ctrl-C from the command line.