### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ keywords = ["robotics", "urdf", "visualization"]
 categories = ["visualization"]
 repository = "https://github.com/openrr/urdf-viz"
 documentation = "http://docs.rs/urdf-viz"
-readme = "README.md"
 exclude = [".github/*", "img/*"]
 edition = "2018"
 


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field if readme is in the default location (`readme = "README.md"`).

