### PR TITLE
Make `o` and `p` alias for `[` and `]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,13 @@ In the GUI, you can do some operations with keyboard and mouse.
 * Move a joint
   * set the angle of a joint by `Up`/`Down` key
   * `Ctrl` + Drag to move the angle of a joint
-  * change the joint to be moved by `[` and `]`
+  * change the joint to be moved by `o` (`[`) and `p` (`]`)
 * Inverse kinematics (only positions)
   * `Shift` + Drag to use inverse kinematics(Y and Z axis)
   * `Shift` + `Ctrl` + Drag to use inverse kinematics(X and Z axis)
   * change the move target for inverse kinematics by `,` or `.`
 * `r` key to set random joints
+* `z` key to reset joint positions and origin
 * Move view point
   * Mouse Right Drag to translate view camera position
   * Mouse Left Drag to look around

--- a/src/bin/urdf-viz.rs
+++ b/src/bin/urdf-viz.rs
@@ -83,8 +83,8 @@ impl LoopIndex {
     }
 }
 
-const HOW_TO_USE_STR: &str = r#"[:    joint ID +1
-]:    joint ID -1
+const HOW_TO_USE_STR: &str = r#"o:    joint ID +1
+p:    joint ID -1
 ,:    IK target ID +1
 .:    IK target ID -1
 Up:   joint angle +0.1
@@ -294,8 +294,8 @@ impl UrdfViewerApp {
     }
     fn handle_key_press(&mut self, code: Key) {
         match code {
-            Key::LBracket => self.increment_move_joint_index(true),
-            Key::RBracket => self.increment_move_joint_index(false),
+            Key::O | Key::LBracket => self.increment_move_joint_index(true),
+            Key::P | Key::RBracket => self.increment_move_joint_index(false),
             Key::Period => {
                 self.index_of_arm.inc();
                 self.update_ik_target_marker();


### PR DESCRIPTION
On the US keyboard layout, op is just to the left of [], so hopefully, this does not worse the usability much.

Closes #56
cc @hunter-digi-ace