### PR TITLE
Alway use latest stable Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,27 +19,27 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Rust
-      # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
-      run: rustup update stable --no-self-update && rustup default stable
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
+        run: rustup update stable --no-self-update
 
-    - name: Install dependencies (linux)
-      run: |
-        sudo apt-get update
-        sudo apt-get install xorg-dev libglu1-mesa-dev
-      if: matrix.os == 'ubuntu-latest'
-    - name: Install dependencies (windows)
-      run: |
-        git clone https://github.com/PistonDevelopers/binaries
-        mv binaries/x86_64/freetype.dll $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
-        mv binaries/x86_64/freetype.lib $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
-      if: matrix.os == 'windows-latest'
+      - name: Install dependencies (linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install xorg-dev libglu1-mesa-dev
+        if: matrix.os == 'ubuntu-latest'
+      - name: Install dependencies (windows)
+        run: |
+          git clone https://github.com/PistonDevelopers/binaries
+          mv binaries/x86_64/freetype.dll $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
+          mv binaries/x86_64/freetype.lib $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
+        if: matrix.os == 'windows-latest'
 
-    - run: cargo fmt -- --check
-    - run: cargo clippy --all-targets
-    - run: cargo build --verbose
-    - run: cargo test --verbose
+      - run: cargo fmt -- --check
+      - run: cargo clippy --all-targets
+      - run: cargo build --verbose
+      - run: cargo test --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: [ "v[0-9]+.*" ]
+    tags: ['v[0-9]+.*']
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update stable
 
       - name: Install dependencies (linux)
         run: |
@@ -25,24 +27,25 @@ jobs:
           sudo apt-get install xorg-dev libglu1-mesa-dev
 
       - run: cargo package
-
       - uses: taiki-e/create-gh-release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   upload-assets:
     if: github.repository_owner == 'openrr'
-    needs: [ create-release ]
+    needs: [create-release]
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - name: Install Rust
+        # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
+        run: rustup update stable --no-self-update
 
       - name: Install dependencies (linux)
         run: |


### PR DESCRIPTION
Stable Rust in the GitHub action environment installed by default sometimes be a bit outdated.