### PR TITLE
Release 0.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urdf-viz"
-version = "0.28.1"
+version = "0.29.0"
 authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 description = "URDF visualization"
 license = "Apache-2.0"


### PR DESCRIPTION
- Summary
  - Avoid conflicts with browser keyboard shortcuts 
  - Depend on k 0.25.0
- Logs
  - 24f507f Use k 0.25.0
  - 53c4a12 Avoid conflicts with browser keyboard shortcuts
  - a6bc7d2 Use #[non_exhaustive] on Opt
  - f844fcc Move from log to tracing