### PR TITLE
Update to clap v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ members = ["examples/wasm"]
 default = ["assimp"]
 assimp = ["assimp-crate", "assimp-sys"]
 
-# Note: k, kiss3d, serde, urdf-rs, and wasm-bindgen are public dependencies.
+# Note: clap, k, kiss3d, serde, urdf-rs, and wasm-bindgen are public dependencies.
 [dependencies]
+clap = { version = "3", features = ["derive"] }
 k = "0.26"
 kiss3d = "0.32"
 nom_stl = "0.2"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
-structopt = "0.3"
 thiserror = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 urdf-rs = "0.6"

--- a/README.md
+++ b/README.md
@@ -233,4 +233,4 @@ curl http://127.0.0.1:7777/get_urdf_text
 * [k](https://github.com/openrr/k): kinematics library which is based on [nalgabra](https://github.com/sebcrozet/nalgebra). It can load URDF files using `urdf-rs`.
 * [assimp-rs](https://github.com/Eljay/assimp-rs): assimp rust interface. `kiss3d` supports `.obj` files natively, but urdf contains `dae` or `stl` files. These files are converted to kiss3d mesh model by `assimp-rs`
 * [urdf-rs](https://github.com/openrr/urdf-rs): URDF file loader.
-* [structopt](https://github.com/TeXitoi/structopt): super easy command line arguments parser.
+* [clap](https://github.com/clap-rs/clap): super easy command line arguments parser.

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@
   limitations under the License.
 */
 
+use clap::Parser;
 use k::nalgebra as na;
 use k::prelude::*;
 use kiss3d::event::{Action, Key, Modifiers, WindowEvent};
@@ -22,7 +23,6 @@ use serde::Deserialize;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
-use structopt::StructOpt;
 use tracing::*;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -697,8 +697,8 @@ impl window::State for AppState {
     }
 }
 
-/// Option for visualizing urdf
-#[derive(StructOpt, Debug, Deserialize)]
+/// URDF visualizer
+#[derive(Parser, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct Opt {
@@ -706,73 +706,73 @@ pub struct Opt {
     #[serde(default, rename = "urdf")]
     pub input_urdf_or_xacro: String,
     /// end link names
-    #[structopt(short = "e", long = "end-link-name")]
+    #[clap(short, long = "end-link-name")]
     #[serde(default)]
     pub end_link_names: Vec<String>,
     /// Show collision element instead of visual
-    #[structopt(short = "c", long = "collision")]
+    #[clap(short = 'c', long = "collision")]
     #[serde(default)]
     pub is_collision: bool,
     /// Disable texture rendering
-    #[structopt(short = "d", long = "disable-texture")]
+    #[clap(short, long)]
     #[serde(default)]
     pub disable_texture: bool,
     /// Port number for web server interface
-    #[structopt(short = "p", long = "web-server-port", default_value = "7777")]
+    #[clap(short = 'p', long, default_value = "7777")]
     #[serde(default = "default_web_server_port")]
     pub web_server_port: u16,
 
-    #[structopt(long = "ignore-ik-position-x")]
+    #[clap(long)]
     #[serde(default)]
     pub ignore_ik_position_x: bool,
-    #[structopt(long = "ignore-ik-position-y")]
+    #[clap(long)]
     #[serde(default)]
     pub ignore_ik_position_y: bool,
-    #[structopt(long = "ignore-ik-position-z")]
+    #[clap(long)]
     #[serde(default)]
     pub ignore_ik_position_z: bool,
 
-    #[structopt(long = "ignore-ik-rotation-x")]
+    #[clap(long)]
     #[serde(default)]
     pub ignore_ik_rotation_x: bool,
-    #[structopt(long = "ignore-ik-rotation-y")]
+    #[clap(long)]
     #[serde(default)]
     pub ignore_ik_rotation_y: bool,
-    #[structopt(long = "ignore-ik-rotation-z")]
+    #[clap(long)]
     #[serde(default)]
     pub ignore_ik_rotation_z: bool,
 
-    #[structopt(long = "bg-color-r", default_value = "0.0")]
+    #[clap(long = "bg-color-r", default_value = "0.0")]
     #[serde(default)]
     pub back_ground_color_r: f32,
-    #[structopt(long = "bg-color-g", default_value = "0.0")]
+    #[clap(long = "bg-color-g", default_value = "0.0")]
     #[serde(default)]
     pub back_ground_color_g: f32,
-    #[structopt(long = "bg-color-b", default_value = "0.3")]
+    #[clap(long = "bg-color-b", default_value = "0.3")]
     #[serde(default = "default_back_ground_color_b")]
     pub back_ground_color_b: f32,
 
-    #[structopt(long = "tile-color1-r", default_value = "0.1")]
+    #[clap(long, default_value = "0.1")]
     #[serde(default = "default_tile_color1")]
     pub tile_color1_r: f32,
-    #[structopt(long = "tile-color1-g", default_value = "0.1")]
+    #[clap(long, default_value = "0.1")]
     #[serde(default = "default_tile_color1")]
     pub tile_color1_g: f32,
-    #[structopt(long = "tile-color1-b", default_value = "0.1")]
+    #[clap(long, default_value = "0.1")]
     #[serde(default = "default_tile_color1")]
     pub tile_color1_b: f32,
 
-    #[structopt(long = "tile-color2-r", default_value = "0.8")]
+    #[clap(long, default_value = "0.8")]
     #[serde(default = "default_tile_color2")]
     pub tile_color2_r: f32,
-    #[structopt(long = "tile-color2-g", default_value = "0.8")]
+    #[clap(long, default_value = "0.8")]
     #[serde(default = "default_tile_color2")]
     pub tile_color2_g: f32,
-    #[structopt(long = "tile-color2-b", default_value = "0.8")]
+    #[clap(long, default_value = "0.8")]
     #[serde(default = "default_tile_color2")]
     pub tile_color2_b: f32,
 
-    #[structopt(long = "ground-height")]
+    #[clap(long)]
     pub ground_height: Option<f32>,
 }
 
@@ -808,5 +808,17 @@ impl Opt {
         debug!("href={}", href);
         let url = url::Url::parse(&href).map_err(|e| e.to_string())?;
         Ok(serde_qs::from_str(url.query().unwrap_or_default()).map_err(|e| e.to_string())?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::IntoApp;
+
+    use super::*;
+
+    #[test]
+    fn assert_app() {
+        Opt::into_app().debug_assert();
     }
 }

--- a/src/bin/urdf-viz.rs
+++ b/src/bin/urdf-viz.rs
@@ -16,13 +16,13 @@
 
 #![warn(rust_2018_idioms)]
 
-use structopt::StructOpt;
+use clap::Parser;
 use tracing::debug;
 use urdf_viz::{app::*, WebServer};
 
 fn main() -> urdf_viz::Result<()> {
     tracing_subscriber::fmt::init();
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     debug!(?opt);
     let urdf_robot = urdf_viz::utils::RobotModel::new(&opt.input_urdf_or_xacro)?;
     let ik_constraints = opt.create_ik_constraints();


### PR DESCRIPTION
```console
$ cargo run -- --help
urdf-viz 
URDF visualizer

USAGE:
    urdf-viz [OPTIONS] <INPUT_URDF_OR_XACRO>

ARGS:
    <INPUT_URDF_OR_XACRO>    Input urdf or xacro

OPTIONS:
        --bg-color-b <BACK_GROUND_COLOR_B>     [default: 0.3]
        --bg-color-g <BACK_GROUND_COLOR_G>     [default: 0.0]
        --bg-color-r <BACK_GROUND_COLOR_R>     [default: 0.0]
    -c, --collision                            Show collision element instead of visual
    -d, --disable-texture                      Disable texture rendering
    -e, --end-link-name <END_LINK_NAMES>       end link names
        --ground-height <GROUND_HEIGHT>        
    -h, --help                                 Print help information
        --ignore-ik-position-x                 
        --ignore-ik-position-y                 
        --ignore-ik-position-z                 
        --ignore-ik-rotation-x                 
        --ignore-ik-rotation-y                 
        --ignore-ik-rotation-z                 
    -p, --web-server-port <WEB_SERVER_PORT>    Port number for web server interface [default: 7777]
        --tile-color1-b <TILE_COLOR1_B>        [default: 0.1]
        --tile-color1-g <TILE_COLOR1_G>        [default: 0.1]
        --tile-color1-r <TILE_COLOR1_R>        [default: 0.1]
        --tile-color2-b <TILE_COLOR2_B>        [default: 0.8]
        --tile-color2-g <TILE_COLOR2_G>        [default: 0.8]
        --tile-color2-r <TILE_COLOR2_R>        [default: 0.8]
```