### PR TITLE
Re-add --version flag that was accidentally removed in 0.33.0

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -698,6 +698,7 @@ impl window::State for AppState {
 
 /// URDF visualizer
 #[derive(Parser, Debug, Deserialize)]
+#[clap(version)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct Opt {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,14 @@
+use std::process::Command;
+
+#[test]
+fn version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_urdf-viz"))
+        .arg("--version")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim(),
+        format!("urdf-viz {}", env!("CARGO_PKG_VERSION"))
+    );
+}


### PR DESCRIPTION
https://github.com/openrr/homebrew-tap/runs/4931259284?check_suite_focus=true

```
==> Testing urdf-viz
==> /home/linuxbrew/.linuxbrew/Cellar/urdf-viz/0.33.0/bin/urdf-viz --version
error: Found argument '--version' which wasn't expected, or isn't valid in this context

	If you tried to supply `--version` as a value rather than a flag, use `-- --version`

USAGE:
    urdf-viz [OPTIONS] <INPUT_URDF_OR_XACRO>

For more information try --help
Error: urdf-viz: failed
```