### PR TITLE
Web Server: Add a request to reload the robot

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -532,6 +532,7 @@ impl AppState {
             self.app.reload(window, |urdf_robot| *urdf_robot = robot);
         }
 
+        #[cfg(not(target_family = "wasm"))]
         if handle.take_reload_request() {
             self.app.reload(window, |urdf_robot| urdf_robot.reload());
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -532,6 +532,10 @@ impl AppState {
             self.app.reload(window, |urdf_robot| *urdf_robot = robot);
         }
 
+        if handle.take_reload_request() {
+            self.app.reload(window, |urdf_robot| urdf_robot.reload());
+        }
+
         while let Some(points) = handle.point_cloud.pop() {
             if points.points.len() == points.colors.len() {
                 self.point_cloud_renderer

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,6 +1,7 @@
 use crossbeam_queue::ArrayQueue;
 use parking_lot::{Mutex, MutexGuard};
 use serde::{Deserialize, Serialize};
+#[cfg(not(target_family = "wasm"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{ops, sync::Arc};
 
@@ -92,6 +93,7 @@ pub struct RobotStateHandle {
     pub(crate) relationship: ArrayQueue<Relationship>,
     pub(crate) urdf_text: Option<Arc<Mutex<String>>>,
     pub(crate) robot: Mutex<Option<RobotModel>>,
+    #[cfg(not(target_family = "wasm"))]
     pub(crate) reload_request: AtomicBool,
 }
 
@@ -110,6 +112,7 @@ impl Default for RobotStateHandle {
             relationship: ArrayQueue::new(QUEUE_CAP),
             urdf_text: None,
             robot: Mutex::default(),
+            #[cfg(not(target_family = "wasm"))]
             reload_request: AtomicBool::new(false),
         }
     }
@@ -206,10 +209,12 @@ impl RobotStateHandle {
         self.robot.lock().take()
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub(crate) fn set_reload_request(&self) {
         self.reload_request.swap(true, Ordering::SeqCst);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub(crate) fn take_reload_request(&self) -> bool {
         self.reload_request.swap(false, Ordering::SeqCst)
     }

--- a/src/web_server.rs
+++ b/src/web_server.rs
@@ -51,11 +51,17 @@ fn app(handle: Handle) -> Router {
     Router::new()
         .route("/set_joint_positions", post(set_joint_positions))
         .route("/set_robot_origin", post(set_robot_origin))
+        .route("/set_reload_request", post(set_reload_request))
         .route("/get_joint_positions", get(get_joint_positions))
         .route("/get_robot_origin", get(get_robot_origin))
         .route("/get_urdf_text", get(get_urdf_text))
         .layer(Extension(handle))
         .layer(tower_http::trace::TraceLayer::new_for_http())
+}
+
+async fn set_reload_request(Extension(handle): Extension<Handle>) -> Json<ResultResponse> {
+    handle.set_reload_request();
+    Json(ResultResponse::SUCCESS)
 }
 
 async fn set_joint_positions(


### PR DESCRIPTION
First of all, thanks so much for the wonderful package,

This PR add a new POST method to reload the robot, one use case is hooking it up to an editor to reload the robot rather than manually moving to the urdf-viz and pressing `l`
