### PR TITLE
Treat web server startup failure as warning when port is not specified

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -888,10 +888,9 @@ pub struct Opt {
     #[structopt(short = "d", long = "disable-texture")]
     #[serde(default)]
     pub disable_texture: bool,
-    /// Port number for web server interface
-    #[structopt(short = "p", long = "web-server-port", default_value = "7777")]
-    #[serde(default = "default_web_server_port")]
-    pub web_server_port: u16,
+    /// Port number for web server interface (default to 7777)
+    #[structopt(short = "p", long = "web-server-port")]
+    pub web_server_port: Option<u16>,
 
     #[structopt(long = "ignore-ik-position-x")]
     #[serde(default)]
@@ -947,9 +946,6 @@ pub struct Opt {
     pub ground_height: Option<f32>,
 }
 
-fn default_web_server_port() -> u16 {
-    7777
-}
 fn default_back_ground_color_b() -> f32 {
     0.3
 }

--- a/src/web_server.rs
+++ b/src/web_server.rs
@@ -40,10 +40,13 @@ impl WebServer {
         self.handle.clone()
     }
 
-    pub fn bind(self) -> impl Future<Output = hyper::Result<()>> + Send {
+    pub fn bind(self) -> crate::errors::Result<impl Future<Output = hyper::Result<()>> + Send> {
         let app = app(self.handle());
 
-        axum::Server::bind(&([0, 0, 0, 0], self.port).into()).serve(app.into_make_service())
+        let addr = ([0, 0, 0, 0], self.port).into();
+        Ok(axum::Server::try_bind(&addr)
+            .map_err(|e| format!("error binding to {addr}: {e}"))?
+            .serve(app.into_make_service()))
     }
 }
 


### PR DESCRIPTION
Closes #171

- If the user didn't specify a port, the user may not need web server, so treat as a warning.
- If the user specified a port, the user intends to use web server, so treat as an error.