### PR TITLE
Statically link binary on Windows MSVC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install xorg-dev libglu1-mesa-dev
         if: startsWith(matrix.os, 'ubuntu')
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        if: startsWith(matrix.os, 'windows')
 
       - run: cargo fmt --all --check
       - run: cargo clippy --all-features --all-targets
       - run: cargo hack build --feature-powerset
       - run: cargo test --all-features
+      - run: cargo build --release
+      # For debugging
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}
+          path: target/release/urdf-viz*
 
   wasm:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install xorg-dev libglu1-mesa-dev
         if: startsWith(matrix.os, 'ubuntu')
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        if: startsWith(matrix.os, 'windows')
 
       - uses: taiki-e/upload-rust-binary-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo apt-get install cmake xorg-dev libglu1-mesa-dev
 ### Download binary
 
 You can download prebuilt binaries from the [release page](https://github.com/openrr/urdf-viz/releases).
-Prebuilt binaries are available for macOS, Linux, and Windows.
+Prebuilt binaries are available for macOS, Linux, and Windows (static executable).
 
 ### Install via Homebrew
 


### PR DESCRIPTION
Allow running prebuilt binary without Microsoft VC++ redistributable