### PR TITLE
Revert "Workaround GitHub Actions bug on Windows"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,6 @@ jobs:
           mv binaries/x86_64/freetype.dll $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
           mv binaries/x86_64/freetype.lib $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
         if: startsWith(matrix.os, 'windows')
-      # https://github.com/actions/runner-images/issues/6627#issuecomment-1328214957
-      - name: Workaround GitHub Actions bug (windows)
-        run: rm -rf C:/Strawberry
-        if: startsWith(matrix.os, 'windows')
 
       - run: cargo fmt --all --check
       - run: cargo clippy --all-targets


### PR DESCRIPTION
This reverts commit 0bc5c8c3ca7b60db62092ac7ca8b3944341a273b.