### PR TITLE
Update urdf-rs version to 0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3"
 thiserror = "1.0"
 tracing = "0.1"
-urdf-rs = "0.7.1"
+urdf-rs = "0.7.2"
 
 assimp-crate = { package = "assimp", version = "0.3.1", optional = true }
 assimp-sys = { version = "0.3.1", optional = true }


### PR DESCRIPTION
Binaries for the latest release are broken (at least on Linux)

I get the following error when I run it

```
thread 'main' panicked at ' not found, mimic not found', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/k-0.30.0/src/urdf.rs:307:40
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I think it's due to not having https://github.com/openrr/urdf-rs/commit/e1c1afe3c20683888e88e57eba1b1b848587a839 and https://github.com/openrr/urdf-rs/commit/d177e38bc1e09c59bd71ae1b4a9b9a9a4afcd7fe when the release was cut