### PR TITLE
Temporarily ignore RUSTSEC-2023-0045

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -9,6 +9,7 @@ ignore = [
     "RUSTSEC-2021-0145", # atty 0.2, transitively dep of structopt (via old clap)
     "RUSTSEC-2021-0119", # nix 0.18/0.20, transitively dep of kiss3d (via old glutin)
     "RUSTSEC-2022-0041", # crossbeam-utils 0.7, transitively dep of kiss3d (via old rusttype)
+    "RUSTSEC-2023-0045", # memoffset 0.5, transitively dep of kiss3d (via old rusttype)
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -9,6 +9,7 @@ glutin
 highp
 libglu
 mediump
+memoffset
 msvc
 nalgebra
 ncollide


### PR DESCRIPTION
```
info: running `cargo deny --workspace --all-features check`
error[unsound]: memoffset allows reading uninitialized memory
    ┌─ /home/runner/work/urdf-viz/urdf-viz/Cargo.lock:130:1
    │
130 │ memoffset 0.5.6 registry+https://github.com/rust-lang/crates.io-index
    │ --------------------------------------------------------------------- unsound advisory detected
    │
    = ID: RUSTSEC-[20](https://github.com/openrr/urdf-viz/actions/runs/5335845079/jobs/9669663045#step:6:21)23-0045
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2023-0045
    = memoffset allows attempt of reading data from address `0` with arbitrary type. This behavior is an undefined behavior because address `0` to `std::mem::size_of<T>` may not have valid bit-pattern with `T`. Old implementation dereferences uninitialized memory obtained from `std::mem::align_of`. Older implementation prior to it allows using uninitialized data obtained from `std::mem::uninitialized` with arbitrary type then compute offset by taking the address of field-projection. This may also result in an undefined behavior for "father" that includes (directly or transitively) type that [does not allow to be uninitialized](https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html).
      
      This flaw was corrected by using `std::ptr::addr_of` in <https://github.com/Gilnaa/memoffset/pull/50>.
    = Announcement: https://github.com/Gilnaa/memoffset/issues/[24](https://github.com/openrr/urdf-viz/actions/runs/5335845079/jobs/9669663045#step:6:25)
    = Solution: Upgrade to >=0.6.2
    = memoffset v0.5.6
      └── crossbeam-epoch v0.8.2
          └── crossbeam-deque v0.7.4
              └── rusttype v0.8.3
                  └── kiss3d v0.35.0
                      └── urdf-viz v0.43.1
                          └── urdf-viz-wasm v0.1.0
```