### PR TITLE
Use namespaced feature (dep:) instead of renaming assimp crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = ["examples/wasm"]
 
 [features]
 default = ["assimp"]
-assimp = ["assimp-crate", "assimp-sys", "tempfile"]
+assimp = ["dep:assimp", "assimp-sys", "tempfile"]
 
 # Note: k, kiss3d, serde, structopt, tokio, urdf-rs, and wasm-bindgen are public dependencies.
 [dependencies]
@@ -30,7 +30,7 @@ thiserror = "1.0"
 tracing = "0.1"
 urdf-rs = "0.8"
 
-assimp-crate = { package = "assimp", version = "0.3.1", optional = true }
+assimp = { version = "0.3.1", optional = true }
 assimp-sys = { version = "0.3.1", optional = true }
 tempfile = { version = "3.8", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,6 @@
 //! `urdf-viz` is written by rust-lang.
 
 #[cfg(feature = "assimp")]
-extern crate assimp_crate as assimp;
-
-#[cfg(feature = "assimp")]
 mod assimp_utils;
 
 pub mod app;


### PR DESCRIPTION
We renamed assimp crate in Cargo.toml due to the limitation that a feature cannot have the same name as a dependency, but namespaced features ([`dep:` syntax](https://doc.rust-lang.org/nightly/cargo/reference/features.html#optional-dependencies)) added in 1.60 allow to work around this limitation.
