### PR TITLE
Use mesh-loader's material & OBJ support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ assimp = ["dep:assimp", "assimp-sys", "tempfile"]
 crossbeam-queue = "0.3.5"
 k = "0.31"
 kiss3d = "0.35"
-mesh-loader = "0.1.3"
+mesh-loader = "0.1.6"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3"

--- a/src/urdf.rs
+++ b/src/urdf.rs
@@ -1,5 +1,6 @@
 use crate::errors::{Error, Result};
 use crate::mesh::load_mesh;
+use crate::utils::is_url;
 use k::nalgebra as na;
 use kiss3d::scene::SceneNode;
 use std::borrow::Cow;
@@ -78,10 +79,7 @@ pub fn add_geometry(
                     }
                 };
                 let replaced_filename = urdf_rs::utils::expand_package_path(&filename, base_dir)?;
-                if !replaced_filename.starts_with("https://")
-                    && !replaced_filename.starts_with("http://")
-                    && !Path::new(&*replaced_filename).exists()
-                {
+                if !is_url(&replaced_filename) && !Path::new(&*replaced_filename).exists() {
                     return Err(Error::from(format!("{replaced_filename} not found")));
                 }
                 filename = replaced_filename.into_owned().into();


### PR DESCRIPTION
- mesh-loader now supports collada materials, so use them.
- mesh-loader now supports obj, so we can use mesh-loader for all formats if assimp is disabled.
- ~~Use mesh-loader's extendable loader to support remote materials. Previously only remote URDFs and meshes were supported.~~ This is disabled for now due to slow. (see also todo comments)

