### PR TITLE
Release 0.45.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urdf-viz"
-version = "0.44.0"
+version = "0.45.0"
 authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 edition = "2021"
 description = "URDF visualization"


### PR DESCRIPTION
Blocked on ~~https://github.com/openrr/urdf-viz/pull/240~~, https://github.com/openrr/urdf-viz/pull/175.

Changes:
- https://github.com/openrr/urdf-viz/pull/240 
- https://github.com/openrr/urdf-viz/pull/228
- https://github.com/openrr/urdf-viz/pull/190
- https://github.com/openrr/urdf-viz/pull/231
- https://github.com/openrr/urdf-viz/pull/234
- https://github.com/openrr/urdf-viz/pull/236
- https://github.com/openrr/urdf-viz/pull/238
- https://github.com/openrr/urdf-viz/pull/239
- https://github.com/openrr/urdf-viz/pull/242
- https://github.com/openrr/urdf-viz/pull/175