### PR TITLE
Remove freetype from pre-requirements

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -2,14 +2,12 @@ cdylib
 collada
 ctxt
 devel
-freetype
 glfw
 glutin
 highp
 libglu
 mediump
 memoffset
-msvc
 nalgebra
 ncollide
 nextage
@@ -21,7 +19,6 @@ rospack
 rosrun
 rustdocflags
 rustflags
-rustlib
 RUSTSEC
 rusttype
 rustup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install xorg-dev libglu1-mesa-dev
         if: startsWith(matrix.os, 'ubuntu')
-      - name: Install dependencies (windows)
-        run: |
-          git clone https://github.com/PistonDevelopers/binaries
-          mv binaries/x86_64/freetype.dll $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
-          mv binaries/x86_64/freetype.lib $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
-        if: startsWith(matrix.os, 'windows')
 
       - run: cargo fmt --all --check
       - run: cargo clippy --all-features --all-targets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,7 @@ jobs:
     needs: [create-release]
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
-        include:
-          - os: windows-latest
-            include-files: binaries/x86_64/freetype.dll,binaries/FTL.TXT,binaries/GPLv2.TXT
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -61,12 +58,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install xorg-dev libglu1-mesa-dev
         if: startsWith(matrix.os, 'ubuntu')
-      - name: Install dependencies (windows)
-        run: |
-          git clone https://github.com/PistonDevelopers/binaries
-          cp binaries/x86_64/freetype.dll $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
-          cp binaries/x86_64/freetype.lib $HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib/
-        if: startsWith(matrix.os, 'windows')
 
       - uses: taiki-e/upload-rust-binary-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -37,19 +37,6 @@ compile `assimp-sys` and `glfw-sys`.
 sudo apt-get install cmake xorg-dev libglu1-mesa-dev
 ```
 
-#### On Windows
-
-You need freetype.lib in your PATH, which is required by `freetype-sys`.
-You can find binaries [here](https://github.com/PistonDevelopers/binaries)
-
-#### On MacOS
-
-Install freetype by brew.
-
-```bash
-brew install freetype
-```
-
 ### Download binary
 
 You can download prebuilt binaries from the [release page](https://github.com/openrr/urdf-viz/releases).


### PR DESCRIPTION
We no longer depend on freetype-sys.

```console
$ cat Cargo.lock | grep freetype
zsh: done       cat Cargo.lock | 
zsh: exit 1     grep freetype
```
