### PR TITLE
Fix CI failure

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -1,15 +1,16 @@
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-vulnerability = "deny"
-unmaintained = "allow" # TODO
-unsound = "deny"
 yanked = "deny"
-notice = "deny"
 ignore = [
     "RUSTSEC-2021-0145", # atty 0.2, transitively dep of structopt (via old clap)
     "RUSTSEC-2021-0119", # nix 0.18/0.20, transitively dep of kiss3d (via old glutin)
     "RUSTSEC-2022-0041", # crossbeam-utils 0.7, transitively dep of kiss3d (via old rusttype)
     "RUSTSEC-2023-0045", # memoffset 0.5, transitively dep of kiss3d (via old rusttype)
+    "RUSTSEC-2020-0016", # unmaintained (net2), transitively dep of kiss3d (via old glutin)
+    "RUSTSEC-2020-0020", # unmaintained (stb_truetype), transitively dep of kiss3d (via old rusttype)
+    "RUSTSEC-2021-0139", # unmaintained (ansi_term), transitively dep of structopt (via old clap)
+    "RUSTSEC-2021-0140", # unmaintained (rusttype), dep of kiss3d
+    "RUSTSEC-2021-0150", # unmaintained (ncollide3d), dep of kiss3d
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
@@ -20,9 +21,6 @@ skip = []
 
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-default = "deny"
-unlicensed = "deny"
-copyleft = "deny"
 unused-allowed-license = "deny"
 private.ignore = true
 allow = [


### PR DESCRIPTION
```
error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /home/runner/work/urdf-viz/urdf-viz/.deny.toml:3:1
  │
3 │ vulnerability = "deny"
  │ ━━━━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /home/runner/work/urdf-viz/urdf-viz/.deny.toml:4:1
  │
4 │ unmaintained = "allow" # TODO
  │ ━━━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /home/runner/work/urdf-viz/urdf-viz/.deny.toml:5:1
  │
5 │ unsound = "deny"
  │ ━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /home/runner/work/urdf-viz/urdf-viz/.deny.toml:7:1
  │
7 │ notice = "deny"
  │ ━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /home/runner/work/urdf-viz/urdf-viz/.deny.toml:24:1
   │
24 │ unlicensed = "deny"
   │ ━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /home/runner/work/urdf-viz/urdf-viz/.deny.toml:25:1
   │
25 │ copyleft = "deny"
   │ ━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /home/runner/work/urdf-viz/urdf-viz/.deny.toml:23:1
   │
23 │ default = "deny"
   │ ━━━━━━━
```