### PR TITLE
Ignore RUSTSEC-2024-0375

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -12,6 +12,7 @@ ignore = [
     "RUSTSEC-2021-0140", # unmaintained (rusttype), dep of kiss3d
     "RUSTSEC-2021-0150", # unmaintained (ncollide3d), dep of kiss3d
     "RUSTSEC-2024-0370", # unmaintained (proc-macro-error), transitively dep of structopt
+    "RUSTSEC-2024-0375", # unmaintained (atty), transitively dep of structopt (via old clap)
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html


### PR DESCRIPTION
```
error[unmaintained]: `atty` is unmaintained
   ┌─ /home/runner/work/urdf-viz/urdf-viz/Cargo.lock:16:1
   │
16 │ atty 0.2.14 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2024-0375
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0375
   ├ The maintainer of `atty` has [published](https://github.com/softprops/atty/commit/5bfdbe9e48c6ca6a4909e8d5b04f5e843a257e93) an official notice that the crate is no longer
     under development, and that users should instead rely on the functionality in the standard library's [`IsTerminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) trait.
     
     ## Alternative(s)
     
     - [std::io::IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) - Stable since Rust 1.70.0 and the recommended replacement per the `atty` maintainer.
     - [is-terminal](https://crates.io/crates/is-terminal) - Standalone crate supporting Rust older than 1.70.0
   ├ Announcement: https://github.com/softprops/atty/issues/57
   ├ Solution: No safe upgrade is available!
   ├ atty v0.2.14
     └── clap v2.34.0
         └── structopt v0.3.26
             └── urdf-viz v0.46.0
                 └── urdf-viz-wasm v0.0.0
```