### PR TITLE
Ignore RUSTSEC-2024-0384 and RUSTSEC-2024-0388

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -13,6 +13,8 @@ ignore = [
     "RUSTSEC-2021-0150", # unmaintained (ncollide3d), dep of kiss3d
     "RUSTSEC-2024-0370", # unmaintained (proc-macro-error), transitively dep of structopt
     "RUSTSEC-2024-0375", # unmaintained (atty), transitively dep of structopt (via old clap)
+    "RUSTSEC-2024-0384", # unmaintained (instant), dep of kiss3d
+    "RUSTSEC-2024-0388", # unmaintained (derivative), transitively dep of kiss3d
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html


### PR DESCRIPTION
```
error[unmaintained]: `derivative` is unmaintained; consider using an alternative
   ┌─ /home/runner/work/urdf-viz/urdf-viz/Cargo.lock:65:1
   │
65 │ derivative 2.2.0 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2024-0388
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0388
   ├ The [`derivative`](https://crates.io/crates/derivative) crate is no longer maintained.
     Consider using any alternative, for instance:
     - [derive_more](https://crates.io/crates/derive_more)
     - [derive-where](https://crates.io/crates/derive-where)
     - [educe](https://crates.io/crates/educe)
   ├ Announcement: https://github.com/mcarton/rust-derivative/issues/117
   ├ Solution: No safe upgrade is available!
   ├ derivative v2.2.0
     └── num_enum v0.4.3
         └── ndk v0.2.1
             ├── ndk-glue v0.2.1
             │   └── winit v0.24.0
             │       └── glutin v0.26.0
             │           └── kiss3d v0.35.0
             │               └── urdf-viz v0.46.0
             │                   └── urdf-viz-wasm v0.0.0
             └── winit v0.24.0 (*)

error[unmaintained]: `instant` is unmaintained
    ┌─ /home/runner/work/urdf-viz/urdf-viz/Cargo.lock:124:1
    │
124 │ instant 0.1.13 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0384
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0384
    ├ This crate is no longer maintained, and the author recommends using the maintained [`web-time`] crate instead.
      
      [`web-time`]: https://crates.io/crates/web-time
    ├ Solution: No safe upgrade is available!
    ├ instant v0.1.13
      ├── kiss3d v0.35.0
      │   └── urdf-viz v0.46.0
      │       └── urdf-viz-wasm v0.0.0
      ├── parking_lot v0.11.2
      │   ├── glutin v0.26.0
      │   │   └── kiss3d v0.35.0 (*)
      │   └── winit v0.24.0
      │       └── glutin v0.26.0 (*)
      ├── parking_lot_core v0.8.6
      │   └── parking_lot v0.11.2 (*)
      └── winit v0.24.0 (*)
```