### PR TITLE
Update .deny.toml to fix CI failure

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -30,8 +30,7 @@ private.ignore = true
 allow = [
     "Apache-2.0",
     "MIT",
-    "Unicode-DFS-2016", # unicode-ident
-    "Unicode-3.0",
+    "Unicode-3.0", # unicode-ident
     "BSD-3-Clause",
     "CC0-1.0",
     "ISC",


### PR DESCRIPTION
```
   ┌─ /home/runner/work/urdf-viz/urdf-viz/.deny.toml:33:6
   │
33 │     "Unicode-DFS-2016", # unicode-ident
   │      ━━━━━━━━━━━━━━━━ unmatched license allowance
```